### PR TITLE
Move from openssl to rustls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - test-rustls
   pull_request:
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "piston_rs"
 description = "An async wrapper for the Piston code execution engine."
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 authors = ["Jonxslays"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,12 @@ categories = ["api-bindings", "asynchronous"]
 name = "piston_rs"
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
+
+[dependencies.reqwest]
+version = "0.11"
+default-features = false
+features = ["json", "rustls-tls"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -62,6 +62,9 @@ impl Client {
 
     /// Creates a new client, with an api key.
     ///
+    /// # Arguments
+    /// - `key` - The api key to use.
+    ///
     /// # Returns
     /// - [`Client`] - The new Client.
     ///
@@ -180,6 +183,9 @@ impl Client {
 
     /// Executes code using a given executor. **This is an http
     /// request**.
+    ///
+    /// # Arguments
+    /// - `executor` - The executor to use.
     ///
     /// # Returns
     /// - [`Result<ExecutorResponse, Box<dyn Error>>`] - The response

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -18,14 +18,20 @@ pub struct ExecResult {
 }
 
 impl ExecResult {
-    /// [`true`] if there was a zero status code returned from
-    /// execution.
+    /// Whether or not the execution was ok.
+    ///
+    /// # Returns
+    /// - [`bool`] - [`true`] if the execution returned a zero exit
+    /// code.
     pub fn is_ok(&self) -> bool {
         self.code == 0
     }
 
-    /// [`true`] if there was a non zero status code returned from
-    /// execution.
+    /// Whether or not the execution produced errors.
+    ///
+    /// # Returns
+    /// - [`bool`] - [`true`] if the execution returned a non zero exit
+    /// code.
     pub fn is_err(&self) -> bool {
         self.code != 0
     }
@@ -46,8 +52,10 @@ pub struct ExecResponse {
 }
 
 impl ExecResponse {
-    /// [`true`] if the response from Piston did not contain an error
-    /// message.
+    /// Whether or not the request to Piston succeeded.
+    ///
+    /// # Returns
+    /// - [`bool`] - [`true`] if a 200 status code was received from Piston.
     pub fn is_ok(&self) -> bool {
         match &self.compile {
             Some(c) => c.is_ok() && self.run.is_ok(),
@@ -55,8 +63,10 @@ impl ExecResponse {
         }
     }
 
-    /// [`true`] if the response from Piston did contain an error
-    /// message.
+    /// Whether or not the request to Piston failed.
+    ///
+    /// # Returns
+    /// - [`bool`] - [`true`] if a non 200 status code was received from Piston.
     pub fn is_err(&self) -> bool {
         match &self.compile {
             Some(c) => c.is_err() || self.run.is_err(),
@@ -74,8 +84,8 @@ pub struct Executor {
     /// **Required** - The language to use for execution. Defaults to a
     /// new `String`.
     pub language: String,
-    /// **Required** - The version of the language to use for execution.
-    /// Defaults to a new `String`.
+    /// The version of the language to use for execution.
+    /// Defaults to "*" (*most recent version*).
     pub version: String,
     /// **Required** - A `Vector` of `File`'s to send to Piston. The
     /// first file in the vector is considered the main file. Defaults
@@ -112,6 +122,7 @@ impl Default for Executor {
     /// let executor = piston_rs::Executor::default();
     ///
     /// assert_eq!(executor.language, String::new());
+    /// assert_eq!(executor.version, String::from("*"));
     /// ```
     fn default() -> Self {
         Self::new()
@@ -122,8 +133,9 @@ impl Executor {
     /// Creates a new executor representing source code to be
     /// executed.
     ///
-    /// Metadata regarding the source language, code, version etc will
-    /// need to be added using the associated method calls.
+    /// Metadata regarding the source language and files will
+    /// need to be added using the associated method calls, and other
+    /// optional fields can be set as well.
     ///
     /// # Returns
     /// - [`Executor`] - The new blank Executor.
@@ -133,11 +145,12 @@ impl Executor {
     /// let executor = piston_rs::Executor::new();
     ///
     /// assert_eq!(executor.language, String::new());
+    /// assert_eq!(executor.version, String::from("*"));
     /// ```
     pub fn new() -> Self {
         Self {
             language: String::new(),
-            version: String::new(),
+            version: String::from("*"),
             files: vec![],
             stdin: String::new(),
             args: vec![],
@@ -165,7 +178,7 @@ impl Executor {
     /// ```
     pub fn reset(&mut self) {
         self.language = String::new();
-        self.version = String::new();
+        self.version = String::from("*");
         self.files = vec![];
         self.stdin = String::new();
         self.args = vec![];
@@ -178,11 +191,9 @@ impl Executor {
     /// Sets the language to use for execution.
     ///
     /// # Arguments
-    ///
     /// - `language` - The language to use.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -200,11 +211,9 @@ impl Executor {
     /// Sets the version of the language to use for execution.
     ///
     /// # Arguments
-    ///
     /// - `version` - The version to use.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -223,11 +232,9 @@ impl Executor {
     /// overwrite any existing files.
     ///
     /// # Arguments
-    ///
     /// - `file` - The file to add.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -248,11 +255,9 @@ impl Executor {
     /// Does not overwrite any existing files.
     ///
     /// # Arguments
-    ///
     /// - `files` - The files to add.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -278,7 +283,6 @@ impl Executor {
     /// executor in place. **Overwrites any existing files.**
     ///
     /// # Arguments
-    ///
     /// - `files` - The files to replace existing files with.
     ///
     /// # Example
@@ -310,11 +314,9 @@ impl Executor {
     /// Sets the text to pass as `stdin` to the program.
     ///
     /// # Arguments
-    ///
     /// - `stdin` - The text to set.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -333,11 +335,9 @@ impl Executor {
     /// overwrite any existing args.
     ///
     /// # Arguments
-    ///
     /// - `arg` - The arg to add.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -356,7 +356,6 @@ impl Executor {
     /// Does not overwrite any existing args.
     ///
     /// # Arguments
-    ///
     /// - `args` - The args to add.
     ///
     /// # Example
@@ -376,7 +375,6 @@ impl Executor {
     /// executor in place. **Overwrites any existing args.**
     ///
     /// # Arguments
-    ///
     /// - `args` - The args to replace existing args with.
     ///
     /// # Example
@@ -401,11 +399,9 @@ impl Executor {
     /// Sets the maximum allowed time for compilation in milliseconds.
     ///
     /// # Arguments
-    ///
     /// - `timeout` - The timeout to set.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -423,11 +419,9 @@ impl Executor {
     /// Sets the maximum allowed time for execution in milliseconds.
     ///
     /// # Arguments
-    ///
     /// - `timeout` - The timeout to set.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -445,11 +439,9 @@ impl Executor {
     /// Sets the maximum allowed memory usage for compilation in bytes.
     ///
     /// # Arguments
-    ///
     /// - `limit` - The memory limit to set.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -467,11 +459,9 @@ impl Executor {
     /// Sets the maximum allowed memory usage for execution in bytes.
     ///
     /// # Arguments
-    ///
     /// - `limit` - The memory limit to set.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,11 +137,9 @@ impl File {
     /// Sets the content of the file.
     ///
     /// # Arguments
-    ///
     /// - `content` - The content to use.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -159,11 +157,9 @@ impl File {
     /// Sets the name of the file.
     ///
     /// # Arguments
-    ///
     /// - `name` - The name to use.
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
@@ -181,12 +177,10 @@ impl File {
     /// Sets the encoding of the file.
     ///
     /// # Arguments
-    ///
     /// - `encoding` - The encoding to use. Must be one of "utf8",
     /// "hex", or "base64".
     ///
     /// # Returns
-    ///
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example


### PR DESCRIPTION
This pull request replaces the openssl dependency with rustls.

# Changes
- rustls for no native openssl dependencies.
- Executor.version now defaults to "*".
- Various docstring clarifications.

Closes #1 
Closes #3 
Closes #4 