### PR TITLE
Fix bug in ExecResponse is_ok and is_err methods

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,6 @@
+branch: true
+ignore-not-existing: true
+llvm: true
+filter: covered
+output-type: html
+output-path: ./target/debug/coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - test-rustls
   pull_request:
 
 jobs:
@@ -26,6 +25,44 @@ jobs:
 
       - name: Run clippy check
         run: cargo clippy
+
+  check-coverage:
+    name: Check coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: "0"
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+
+      - name: Generate coverage report
+        uses: actions-rs/grcov@v0.1
+
+      - name: Verify coverage >= 80%
+        run: |
+          COVERAGE=$(grep -oP "message\":\"\K(\d+)" ./target/debug/coverage/coverage.json);
+          if [ $COVERAGE -lt 80 ]; then
+            echo "Coverage failing with: $COVERAGE%";
+            exit 1;
+          else
+            echo "Coverage passing with: $COVERAGE%";
+            exit 0;
+          fi
 
   test-and-build:
     name: Test and build

--- a/README.md
+++ b/README.md
@@ -55,10 +55,8 @@ async fn main() {
             println!("Language: {}", response.language);
             println!("Version: {}", response.version);
 
-            if response.is_err() {
-                if let Some(c) = response.compile {
-                    println!("Compilation: {}", c.output);
-                }
+            if let Some(c) = response.compile {
+                println!("Compilation: {}", c.output);
             }
 
             println!("Output: {}", response.run.output);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -37,6 +37,21 @@ impl ExecResult {
     }
 }
 
+/// Raw response received from Piston
+#[doc(hidden)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RawExecResponse {
+    /// The language that was used.
+    pub language: String,
+    /// The version of the language that was used.
+    pub version: String,
+    /// The result Piston sends detailing execution.
+    pub run: ExecResult,
+    /// The optional result Piston sends detailing compilation. This
+    /// will be [`None`] for non-compiled languages.
+    pub compile: Option<ExecResult>,
+}
+
 /// A response returned by Piston when executing code.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExecResponse {


### PR DESCRIPTION
This pull requests adds an additional `status` field to the `ExecResponse` which signified the http status received during a request to Piston. 

Previously the `ExecResult` code field was used to determine whether the response was ok or err.

- Add coverage check to CI
- Stop adding error message to stdout, only stderr on bad responses.
- Adds tests for `ExecResponse`, ~~there were none???~~.

Closes #6 
