### PR TITLE
Add ability to create File objects from existing files (#11)

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -214,6 +214,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.language, "rust".to_string());
     /// ```
+    #[must_use]
     pub fn set_language(mut self, language: &str) -> Self {
         self.language = language.to_lowercase();
         self
@@ -234,6 +235,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.version, "1.50.0".to_string());
     /// ```
+    #[must_use]
     pub fn set_version(mut self, version: &str) -> Self {
         self.version = version.to_string();
         self
@@ -257,6 +259,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.files, [file].to_vec());
     /// ```
+    #[must_use]
     pub fn add_file(mut self, file: File) -> Self {
         self.files.push(file);
         self
@@ -284,6 +287,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.files, files);
     /// ```
+    #[must_use]
     pub fn add_files(mut self, files: Vec<File>) -> Self {
         self.files.extend(files);
         self
@@ -337,6 +341,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.stdin, "Fearless concurrency".to_string());
     /// ```
+    #[must_use]
     pub fn set_stdin(mut self, stdin: &str) -> Self {
         self.stdin = stdin.to_string();
         self
@@ -358,6 +363,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.args, vec!["--verbose".to_string()]);
     /// ```
+    #[must_use]
     pub fn add_arg(mut self, arg: &str) -> Self {
         self.args.push(arg.to_string());
         self
@@ -376,6 +382,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.args, vec!["--verbose".to_string()]);
     /// ```
+    #[must_use]
     pub fn add_args(mut self, args: Vec<&str>) -> Self {
         self.args.extend(args.iter().map(|a| a.to_string()));
         self
@@ -422,6 +429,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.compile_timeout, 5000);
     /// ```
+    #[must_use]
     pub fn set_compile_timeout(mut self, timeout: isize) -> Self {
         self.compile_timeout = timeout;
         self
@@ -442,6 +450,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.run_timeout, 1500);
     /// ```
+    #[must_use]
     pub fn set_run_timeout(mut self, timeout: isize) -> Self {
         self.run_timeout = timeout;
         self
@@ -462,6 +471,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.compile_memory_limit, 100_000_000);
     /// ```
+    #[must_use]
     pub fn set_compile_memory_limit(mut self, limit: isize) -> Self {
         self.compile_memory_limit = limit;
         self
@@ -482,6 +492,7 @@ impl Executor {
     ///
     /// assert_eq!(executor.run_memory_limit, 100_000_000);
     /// ```
+    #[must_use]
     pub fn set_run_memory_limit(mut self, limit: isize) -> Self {
         self.run_memory_limit = limit;
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,12 @@ impl Default for File {
 impl File {
     /// Creates a new [`File`].
     ///
+    /// # Arguments
+    /// - `name` - The name to use.
+    /// - `content` - The content to use.
+    /// - `encoding` - The encoding to use. Must be one of "utf8",
+    /// "hex", or "base64".
+    ///
     /// # Returns
     /// - [`File`] - The new File.
     ///
@@ -136,6 +142,9 @@ impl File {
     }
 
     /// Creates a new [`File`] from an existing file on disk.
+    ///
+    /// # Arguments
+    /// - `path` - The path to the file.
     ///
     /// # Returns
     /// - [`File`] - The new File.
@@ -206,11 +215,11 @@ impl File {
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// let file = piston_rs::File::default()
-    ///     .set_content("print(\"Hello, world!\")");
+    ///     .load_contents_from("path/to/script.sh");
     ///
-    /// assert_eq!(file.content, "print(\"Hello, world!\")".to_string());
+    /// assert!(file.content.contains("<contents of file>"));
     /// ```
     pub fn load_contents_from(mut self, path: &str) -> Self {
         let path = PathBuf::from(path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process;
 
 mod client;
 mod executor;
@@ -102,9 +101,9 @@ impl Default for File {
     /// ```
     fn default() -> Self {
         Self {
-            name: "".to_string(),
-            content: "".to_string(),
-            encoding: "utf8".to_string(),
+            name: String::from(""),
+            content: String::from(""),
+            encoding: String::from("utf8"),
         }
     }
 }
@@ -160,18 +159,23 @@ impl File {
     pub fn load_from(path: &str) -> Self {
         let path = PathBuf::from(path);
 
+        if !path.is_file() {
+            println!("File does not exist, or is a directory -- using defaults");
+            return File::default();
+        }
+
         let name = match path.file_name() {
             Some(n) => n.to_str().unwrap_or("Invalid file name"),
             None => {
-                println!("Invalid path name");
-                process::exit(1);
+                println!("Invalid file name");
+                ""
             }
         };
 
         Self {
             name: name.to_string(),
             content: File::load_contents(&path),
-            encoding: "utf8".to_string(),
+            encoding: String::from("utf8"),
         }
     }
 
@@ -180,7 +184,7 @@ impl File {
             Ok(c) => c,
             Err(e) => {
                 println!("{}", e);
-                process::exit(1);
+                String::from("")
             }
         }
     }
@@ -280,5 +284,13 @@ mod test_file_private {
         let contents = File::load_contents(&path);
 
         assert!(contents.contains("mod test_file_private {"));
+    }
+
+    #[test]
+    fn test_load_contents_non_existent() {
+        let path = PathBuf::from("/path/doesnt/exist");
+        let contents = File::load_contents(&path);
+
+        assert_eq!(contents, String::from(""))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,9 +346,13 @@ mod test_file_private {
 
         assert!(contents.is_err());
         let err = contents.unwrap_err();
+        let expd_err = match cfg!(windows) {
+            true => String::from("The system cannot find the path specified. (os error 3)"),
+            false => String::from("No such file or directory (os error 2)"),
+        };
 
-        assert!(err.details.contains("No such file"));
-        assert!(format!("{}", err).contains("No such file"));
+        assert_eq!(err.details, expd_err);
+        assert_eq!(format!("{}", err), expd_err);
 
         let err2 = err.clone();
         assert_eq!(err.details, err2.details);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,45 @@ pub struct Runtime {
     pub aliases: Vec<String>,
 }
 
+/// The result from attempting to load a [`File`].
+type LoadResult<T> = Result<T, LoadError>;
+
+/// The error that is returned when loading from a [`File`] on disk
+/// fails for any reason.
+#[derive(Debug, Clone)]
+pub struct LoadError {
+    /// The details of this error.
+    pub details: String,
+}
+
+impl LoadError {
+    /// Generates a new [`LoadError`].
+    ///
+    /// # Arguments
+    /// - `details` - The details of the error.
+    ///
+    /// # Returns
+    /// - [`LoadError`] - The new error.
+    ///
+    /// # Examples
+    /// ```
+    /// let e = piston_rs::LoadError::new("err");
+    ///
+    /// assert_eq!(e.details, "err".to_string())
+    /// ```
+    pub fn new(details: &str) -> Self {
+        Self {
+            details: details.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.details)
+    }
+}
+
 /// A file that contains source code to be executed.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct File {
@@ -150,42 +189,37 @@ impl File {
     ///
     /// # Example
     /// ```
-    /// let file = piston_rs::File::load_from("src/lib.rs");
+    /// let file = piston_rs::File::load_from("src/lib.rs").unwrap();
     ///
     /// assert!(file.content.contains("pub fn load_from"));
     /// assert_eq!(file.name, "lib.rs".to_string());
     /// assert_eq!(file.encoding, "utf8".to_string());
     /// ```
-    pub fn load_from(path: &str) -> Self {
+    pub fn load_from(path: &str) -> LoadResult<Self> {
         let path = PathBuf::from(path);
 
         if !path.is_file() {
-            println!("File does not exist, or is a directory -- using defaults");
-            return File::default();
+            return Err(LoadError::new("File does not exist, or is a directory"));
         }
 
         let name = match path.file_name() {
-            Some(n) => n.to_str().unwrap_or("Invalid file name"),
+            Some(n) => n.to_string_lossy(),
             None => {
-                println!("Invalid file name");
-                ""
+                return Err(LoadError::new("Unable to parse file name"));
             }
         };
 
-        Self {
+        Ok(Self {
             name: name.to_string(),
-            content: File::load_contents(&path),
+            content: File::load_contents(&path)?,
             encoding: String::from("utf8"),
-        }
+        })
     }
 
-    fn load_contents(path: &Path) -> String {
-        match fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(e) => {
-                println!("{}", e);
-                String::new()
-            }
+    fn load_contents(path: &Path) -> LoadResult<String> {
+        match fs::read_to_string(path) {
+            Ok(content) => Ok(content),
+            Err(e) => Err(LoadError::new(&e.to_string())),
         }
     }
 
@@ -204,6 +238,7 @@ impl File {
     ///
     /// assert_eq!(file.content, "print(\"Hello, world!\")".to_string());
     /// ```
+    #[must_use]
     pub fn set_content(mut self, content: &str) -> Self {
         self.content = content.to_string();
         self
@@ -223,12 +258,13 @@ impl File {
     /// let file = piston_rs::File::default()
     ///     .load_contents_from("src/lib.rs");
     ///
-    /// assert!(file.content.contains("pub fn load_contents_from"));
+    /// assert!(file.is_ok());
+    /// assert!(file.unwrap().content.contains("pub fn load_contents_from"));
     /// ```
-    pub fn load_contents_from(mut self, path: &str) -> Self {
+    pub fn load_content_from(mut self, path: &str) -> LoadResult<Self> {
         let path = PathBuf::from(path);
-        self.content = File::load_contents(&path);
-        self
+        self.content = File::load_contents(&path)?;
+        Ok(self)
     }
 
     /// Sets the name of the file.
@@ -246,6 +282,7 @@ impl File {
     ///
     /// assert_eq!(file.name, "__main__.py".to_string());
     /// ```
+    #[must_use]
     pub fn set_name(mut self, name: &str) -> Self {
         self.name = name.to_string();
         self
@@ -267,6 +304,7 @@ impl File {
     ///
     /// assert_eq!(file.encoding, "hex".to_string());
     /// ```
+    #[must_use]
     pub fn set_encoding(mut self, encoding: &str) -> Self {
         self.encoding = encoding.to_string();
         self
@@ -276,12 +314,13 @@ impl File {
 #[cfg(test)]
 mod test_file_private {
     use super::File;
+    use super::Runtime;
     use std::path::PathBuf;
 
     #[test]
     fn test_load_contents() {
         let path = PathBuf::from(file!());
-        let contents = File::load_contents(&path);
+        let contents = File::load_contents(&path).unwrap();
 
         assert!(contents.contains("mod test_file_private {"));
     }
@@ -291,6 +330,31 @@ mod test_file_private {
         let path = PathBuf::from("/path/doesnt/exist");
         let contents = File::load_contents(&path);
 
-        assert_eq!(contents, String::new())
+        assert!(contents.is_err());
+        let err = contents.unwrap_err();
+
+        assert!(err.details.contains("No such file"));
+        assert!(format!("{}", err).contains("No such file"));
+
+        let err2 = err.clone();
+        assert_eq!(err.details, err2.details);
+    }
+
+    #[test]
+    fn test_runtime_creation() {
+        let rt = Runtime {
+            language: "clojure".to_string(),
+            version: "9000".to_string(),
+            aliases: vec![],
+        };
+
+        let rt2 = rt.clone();
+        assert_eq!(rt.language, rt2.language);
+        assert_eq!(rt.version, rt2.version);
+        assert_eq!(rt.aliases, rt2.aliases);
+
+        assert_eq!(rt.language, "clojure".to_string());
+        assert_eq!(rt.version, "9000".to_string());
+        assert!(rt.aliases.is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,20 @@ impl File {
         })
     }
 
+    /// Loads the contents of the given file.
+    ///
+    /// # Arguments
+    /// - `path` - The path to the file.
+    ///
+    /// # Returns
+    /// - [`String`] - The file's contents.
+    ///
+    /// # Example
+    /// ```ignore # Fails to compile (private function)
+    /// let content = piston_rs::File::load_contents("src/lib.rs").unwrap();
+    ///
+    /// assert!(content.contains("fn load_contents"));
+    /// ```
     fn load_contents(path: &Path) -> LoadResult<String> {
         match fs::read_to_string(path) {
             Ok(content) => Ok(content),
@@ -256,10 +270,10 @@ impl File {
     /// # Example
     /// ```
     /// let file = piston_rs::File::default()
-    ///     .load_contents_from("src/lib.rs");
+    ///     .load_content_from("src/lib.rs");
     ///
     /// assert!(file.is_ok());
-    /// assert!(file.unwrap().content.contains("pub fn load_contents_from"));
+    /// assert!(file.unwrap().content.contains("pub fn load_content_from"));
     /// ```
     pub fn load_content_from(mut self, path: &str) -> LoadResult<Self> {
         let path = PathBuf::from(path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,8 @@ impl Default for File {
     /// ```
     fn default() -> Self {
         Self {
-            name: String::from(""),
-            content: String::from(""),
+            name: String::new(),
+            content: String::new(),
             encoding: String::from("utf8"),
         }
     }
@@ -149,11 +149,11 @@ impl File {
     /// - [`File`] - The new File.
     ///
     /// # Example
-    /// ```no_run
-    /// let file = piston_rs::File::load_from("path/to/script.sh");
+    /// ```
+    /// let file = piston_rs::File::load_from("src/lib.rs");
     ///
-    /// assert!(file.content.contains("<contents of file>"));
-    /// assert_eq!(file.name, "script.sh".to_string());
+    /// assert!(file.content.contains("pub fn load_from"));
+    /// assert_eq!(file.name, "lib.rs".to_string());
     /// assert_eq!(file.encoding, "utf8".to_string());
     /// ```
     pub fn load_from(path: &str) -> Self {
@@ -184,7 +184,7 @@ impl File {
             Ok(c) => c,
             Err(e) => {
                 println!("{}", e);
-                String::from("")
+                String::new()
             }
         }
     }
@@ -219,11 +219,11 @@ impl File {
     /// - [`Self`] - For chained method calls.
     ///
     /// # Example
-    /// ```no_run
+    /// ```
     /// let file = piston_rs::File::default()
-    ///     .load_contents_from("path/to/script.sh");
+    ///     .load_contents_from("src/lib.rs");
     ///
-    /// assert!(file.content.contains("<contents of file>"));
+    /// assert!(file.content.contains("pub fn load_contents_from"));
     /// ```
     pub fn load_contents_from(mut self, path: &str) -> Self {
         let path = PathBuf::from(path);
@@ -291,6 +291,6 @@ mod test_file_private {
         let path = PathBuf::from("/path/doesnt/exist");
         let contents = File::load_contents(&path);
 
-        assert_eq!(contents, String::from(""))
+        assert_eq!(contents, String::new())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@
 
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::process;
-use std::path::PathBuf;
 
 mod client;
 mod executor;
@@ -175,7 +175,7 @@ impl File {
         }
     }
 
-    fn load_contents(path: &PathBuf) -> String {
+    fn load_contents(path: &Path) -> String {
         match fs::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => {
@@ -266,5 +266,19 @@ impl File {
     pub fn set_encoding(mut self, encoding: &str) -> Self {
         self.encoding = encoding.to_string();
         self
+    }
+}
+
+#[cfg(test)]
+mod test_file_private {
+    use super::File;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_load_contents() {
+        let path = PathBuf::from(file!());
+        let contents = File::load_contents(&path);
+
+        assert!(contents.contains("mod test_file_private {"));
     }
 }


### PR DESCRIPTION
This PR:

* Adds the `load_from` classmethod and the `load_contents_from` method to load contents from existing files (it also adds a private `load_contents` method which the two public methods share)
* Corrects some issues in the docs
* Adds relevant tests

Closes #11.